### PR TITLE
Removed context from BasePresenter

### DIFF
--- a/core/src/main/java/ar/com/wolox/wolmo/core/presenter/BasePresenter.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/presenter/BasePresenter.java
@@ -1,31 +1,19 @@
 package ar.com.wolox.wolmo.core.presenter;
 
 
-import android.content.Context;
-
 /**
  * Abstract presenter that provides the view to the specific presenters.
  */
 public class BasePresenter<T> {
 
     private T mViewInstance;
-    private Context mContext;
 
     public BasePresenter(T viewInstance) {
         this.mViewInstance = viewInstance;
     }
 
-    public BasePresenter(T viewInstance, Context context) {
-        this.mViewInstance = viewInstance;
-        this.mContext = context;
-    }
-
     protected T getView() {
         return mViewInstance;
-    }
-
-    protected Context getContext() {
-        return mContext;
     }
 
     public boolean isViewAttached() {
@@ -34,6 +22,5 @@ public class BasePresenter<T> {
 
     public void detachView() {
         mViewInstance = null;
-        mContext = null;
     }
 }


### PR DESCRIPTION
## Removed context from BasePresenter

Removed the context from the `BasePresenter` constructor and instance variable. This is for three reasons:
1) encourage decoupling Presenters from the Android platform
2) simplifying non abstracts presenters implementations
3) encourage dependency injection of contexts (if needed) in presenters that needs it in the future on a case by case basis

This decision was made by a suggestion of @emalamela and an analysis by @alvarez-fabian , who looked into the code of Prime and found out that the context in presenters was almost always unnecessary.
