### PR TITLE
Added gallery/camera image fetching utilities

### DIFF
--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
@@ -1,0 +1,167 @@
+package ar.com.wolox.wolmo.core.fragment;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+
+import ar.com.wolox.wolmo.core.permission.PermissionListener;
+import ar.com.wolox.wolmo.core.permission.PermissionManager;
+import ar.com.wolox.wolmo.core.presenter.BasePresenter;
+import ar.com.wolox.wolmo.core.util.ImageUtils;
+
+public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFragment<T> {
+
+    private static final String[] CAMERA_PERMISSIONS = new String[]{
+            Manifest.permission.CAMERA,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE};
+
+    private static final String[] GALLERY_PERMISSIONS = new String[]{
+            Manifest.permission.READ_EXTERNAL_STORAGE};
+
+    private static final int INTENT_CODE_IMAGE_GALLERY = 9000;
+    private static final int INTENT_CODE_IMAGE_CAMERA = 9001;
+
+    private Uri mPictureTakenUri;
+    private OnImageReturnCallback mImageCallback;
+
+    /* Error types */
+    protected enum Error {
+        USER_CANCELED,      // Image selection canceled by the user
+        ERROR_DATA,         // Image URI was no returned
+        ERROR_UNKNOWN,      // Unknown error
+        PERMISSION_DENIED   // Gallery/Camera Permission denied
+    }
+
+    /* Callback for image selection */
+    public interface OnImageReturnCallback {
+
+        void success(Uri imageUri);
+
+        void error(Error error);
+
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (resultCode == Activity.RESULT_OK) {
+            switch (requestCode) {
+                // Gallery request codes
+                case INTENT_CODE_IMAGE_GALLERY:
+                    if (data != null) {
+                        mImageCallback.success(data.getData());
+                    } else {
+                        notifyError(Error.ERROR_DATA);
+                    }
+                    break;
+
+                // Camera request codes
+                case INTENT_CODE_IMAGE_CAMERA:
+                    // Add the new picture to the device's gallery app
+                    ImageUtils.addPictureToDeviceGallery(mPictureTakenUri);
+                    mImageCallback.success(mPictureTakenUri);
+                    break;
+
+                // Unknown request code
+                default:
+                    notifyError(Error.ERROR_UNKNOWN);
+            }
+        } else if (resultCode == Activity.RESULT_CANCELED) {
+
+            switch (requestCode) {
+                case INTENT_CODE_IMAGE_GALLERY:
+                case INTENT_CODE_IMAGE_CAMERA:
+                    notifyError(Error.USER_CANCELED);
+                    break;
+
+                default:
+                    notifyError(Error.ERROR_UNKNOWN);
+            }
+
+        }
+
+        // Remove callbacks references after processing images
+        clearCallbacks();
+    }
+
+    private void clearCallbacks() {
+        mImageCallback = null;
+    }
+
+    private void notifyError(Error error) {
+        if (mImageCallback != null) {
+            mImageCallback.error(error);
+        }
+    }
+
+    @StringRes
+    protected abstract int galleryErrorResId();
+
+    @StringRes
+    protected abstract int cameraErrorResId();
+
+    @NonNull
+    protected abstract String pictureTakenFilename();
+
+    /**
+     * Start a request for an image from Gallery
+     *
+     * @param onImageReturnCallback callback for request result
+     */
+    protected void selectImageFromGallery(final OnImageReturnCallback onImageReturnCallback) {
+        PermissionManager.getInstance().requirePermission(
+                this,
+                new PermissionListener() {
+                    @Override
+                    public void onPermissionsGranted() {
+                        mImageCallback = onImageReturnCallback;
+
+                        ImageUtils.getImageFromGallery(
+                                GetImageFragment.this,
+                                INTENT_CODE_IMAGE_GALLERY,
+                                galleryErrorResId());
+                    }
+
+                    @Override
+                    public void onPermissionsDenied(String[] deniedPermissions) {
+                        onImageReturnCallback.error(Error.PERMISSION_DENIED);
+                    }
+                },
+                GALLERY_PERMISSIONS);
+    }
+
+    /**
+     * Start a request for an image from Camera
+     *
+     * @param onImageReturnCallback callback for request result
+     */
+    protected void takePicture(final OnImageReturnCallback onImageReturnCallback) {
+        PermissionManager.getInstance().requirePermission(
+                this,
+                new PermissionListener() {
+                    @Override
+                    public void onPermissionsGranted() {
+                        mImageCallback = onImageReturnCallback;
+
+                        mPictureTakenUri =
+                                ImageUtils.getImageFromCamera(
+                                        GetImageFragment.this,
+                                        INTENT_CODE_IMAGE_CAMERA,
+                                        pictureTakenFilename(),
+                                        ImageUtils.PNG,
+                                        cameraErrorResId());
+                    }
+
+                    @Override
+                    public void onPermissionsDenied(String[] deniedPermissions) {
+                        onImageReturnCallback.error(Error.PERMISSION_DENIED);
+                    }
+                },
+                CAMERA_PERMISSIONS);
+    }
+
+}

--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
@@ -38,8 +38,19 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
     /* Callback for image selection */
     public interface OnImageReturnCallback {
 
+        /**
+         * Method for when the image retrieval was a success, exposing the {@link Uri} of the image
+         *
+         * @param imageUri retrieved image
+         */
         void success(Uri imageUri);
 
+        /**
+         * Method for when the image retrieval was a failure, exposing the correponding
+         * {@link Error} instance
+         *
+         * @param error describing the failure reason
+         */
         void error(Error error);
 
     }
@@ -50,7 +61,6 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
 
         if (resultCode == Activity.RESULT_OK) {
             switch (requestCode) {
-                // Gallery request codes
                 case INTENT_CODE_IMAGE_GALLERY:
                     if (data != null) {
                         mImageCallback.success(data.getData());
@@ -59,19 +69,15 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
                     }
                     break;
 
-                // Camera request codes
                 case INTENT_CODE_IMAGE_CAMERA:
-                    // Add the new picture to the device's gallery app
                     ImageUtils.addPictureToDeviceGallery(mPictureTakenUri);
                     mImageCallback.success(mPictureTakenUri);
                     break;
 
-                // Unknown request code
                 default:
                     notifyError(Error.ERROR_UNKNOWN);
             }
         } else if (resultCode == Activity.RESULT_CANCELED) {
-
             switch (requestCode) {
                 case INTENT_CODE_IMAGE_GALLERY:
                 case INTENT_CODE_IMAGE_CAMERA:
@@ -84,7 +90,6 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
 
         }
 
-        // Remove callbacks references after processing images
         clearCallbacks();
     }
 

--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
@@ -39,19 +39,19 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
     public interface OnImageReturnCallback {
 
         /**
-         * Method for when the image retrieval was a success, exposing the {@link Uri} of the image
+         * Method for when the image retrieval was a success, exposing the {@link Uri} of the image.
          *
-         * @param imageUri retrieved image
+         * @param imageUri of the retrieved image
          */
-        void success(Uri imageUri);
+        void success(@NonNull Uri imageUri);
 
         /**
          * Method for when the image retrieval was a failure, exposing the correponding
-         * {@link Error} instance
+         * {@link Error} instance.
          *
          * @param error describing the failure reason
          */
-        void error(Error error);
+        void error(@NonNull Error error);
 
     }
 
@@ -113,11 +113,12 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
     protected abstract String pictureTakenFilename();
 
     /**
-     * Start a request for an image from Gallery
+     * Start a request for an image from Gallery.
      *
      * @param onImageReturnCallback callback for request result
      */
-    protected void selectImageFromGallery(final OnImageReturnCallback onImageReturnCallback) {
+    protected void selectImageFromGallery(
+            @NonNull final OnImageReturnCallback onImageReturnCallback) {
         PermissionManager.getInstance().requirePermission(
                 this,
                 new PermissionListener() {
@@ -140,11 +141,12 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
     }
 
     /**
-     * Start a request for an image from Camera
+     * Start a request for an image from Camera.
      *
      * @param onImageReturnCallback callback for request result
      */
-    protected void takePicture(final OnImageReturnCallback onImageReturnCallback) {
+    protected void takePicture(
+            @NonNull final OnImageReturnCallback onImageReturnCallback) {
         PermissionManager.getInstance().requirePermission(
                 this,
                 new PermissionListener() {

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
@@ -4,11 +4,15 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * Utils class for managing {@link File}s.
+ */
 public class FileUtils {
 
     private FileUtils() {}
@@ -21,26 +25,27 @@ public class FileUtils {
      *
      * @param filename File name, used as described above
      * @param extension ImageFormat of the file, used as described above
+     *
+     * @return {@link File} result of the creation
+     *
+     * @throws IOException if a file could not be created
      */
-    public static File createFile(String filename, String extension) throws IOException {
+    public static File createFile(
+            @NonNull String filename, @NonNull String extension) throws IOException {
         File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
 
-        return File.createTempFile(
-                filename,
-                extension,
-                storageDir
-        );
+        return File.createTempFile(filename, extension, storageDir);
     }
 
     /**
-     * Get the physical path to a stored File by providing a URI of a content provider
+     * Get the physical path to a stored File by providing a URI of a content provider.
      *
      * @param fileUri A URI of a content provider pointing to an image resource
      *
      * @return A path to the real file location, or null if it can't find it
      */
     @Nullable
-    public static String getRealPathFromUri(Uri fileUri) {
+    public static String getRealPathFromUri(@NonNull Uri fileUri) {
         Cursor cursor = null;
         try {
             String[] proj = {MediaStore.Images.Media.DATA};
@@ -60,4 +65,5 @@ public class FileUtils {
             }
         }
     }
+
 }

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
@@ -4,6 +4,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,9 +26,9 @@ public class FileUtils {
         File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
 
         return File.createTempFile(
-                filename,                           /* name */
-                extension,                          /* extension */
-                storageDir                          /* directory */
+                filename,
+                extension,
+                storageDir
         );
     }
 
@@ -36,8 +37,9 @@ public class FileUtils {
      *
      * @param fileUri A URI of a content provider pointing to an image resource
      *
-     * @return A path to the real file location
+     * @return A path to the real file location, or null if it can't find it
      */
+    @Nullable
     public static String getRealPathFromUri(Uri fileUri) {
         Cursor cursor = null;
         try {
@@ -46,6 +48,9 @@ public class FileUtils {
                     .getAppContext()
                     .getContentResolver()
                     .query(fileUri, proj, null, null, null);
+
+            if (cursor == null) return null;
+
             int columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
             cursor.moveToFirst();
             return cursor.getString(columnIndex);

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
@@ -34,6 +34,11 @@ public class FileUtils {
             @NonNull String filename, @NonNull String extension) throws IOException {
         File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
 
+        //The suffix will be appended as it is, we need to add the dot manually
+        if (!extension.startsWith("."))
+            extension = "." + extension;
+        }
+
         return File.createTempFile(filename, extension, storageDir);
     }
 

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
@@ -1,0 +1,58 @@
+package ar.com.wolox.wolmo.core.util;
+
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.MediaStore;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FileUtils {
+
+    private FileUtils() {}
+
+    /**
+     * Creates a file in the external public directory to store data.
+     *
+     * The file ends up being stored as:
+     *  filename + "." + extension
+     *
+     * @param filename File name, used as described above
+     * @param extension ImageFormat of the file, used as described above
+     */
+    public static File createFile(String filename, String extension) throws IOException {
+        File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
+
+        return File.createTempFile(
+                filename,                           /* name */
+                extension,                          /* extension */
+                storageDir                          /* directory */
+        );
+    }
+
+    /**
+     * Get the physical path to a stored File by providing a URI of a content provider
+     *
+     * @param fileUri A URI of a content provider pointing to an image resource
+     *
+     * @return A path to the real file location
+     */
+    public static String getRealPathFromUri(Uri fileUri) {
+        Cursor cursor = null;
+        try {
+            String[] proj = {MediaStore.Images.Media.DATA};
+            cursor = ContextUtils
+                    .getAppContext()
+                    .getContentResolver()
+                    .query(fileUri, proj, null, null, null);
+            int columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+            cursor.moveToFirst();
+            return cursor.getString(columnIndex);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+}

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
@@ -1,0 +1,147 @@
+package ar.com.wolox.wolmo.core.util;
+
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringDef;
+import android.support.annotation.StringRes;
+import android.support.v4.app.Fragment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+public class ImageUtils {
+
+    @Retention(SOURCE)
+    @StringDef({
+            PNG,
+            JPG
+    })
+    public @interface ImageFormat {
+    }
+
+    public static final String PNG = "png";
+    public static final String JPG = "jpg";
+
+    private ImageUtils() {
+    }
+
+    /**
+     * Triggers an intent to go to the device's image gallery and returns an URI with the file
+     * <p>
+     * <p/>
+     * Override the onActivityResult method in your fragment and specify behaviour
+     * for the provided request code. The selected image URI will be
+     * returned in the data variable of the activity result.
+     *
+     * @param fragment A fragment where the get image intent is going to be called
+     * @author juanignaciomolina
+     */
+    public static void getImageFromGallery(Fragment fragment, int requestCode, @StringRes int errorResId) {
+        Intent i = new Intent(
+                Intent.ACTION_PICK,
+                MediaStore.Images.Media.INTERNAL_CONTENT_URI);
+        i.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+
+        // Ensure that there's a gallery app to handle the intent
+        if (i.resolveActivity(ContextUtils.getAppContext().getPackageManager()) != null)
+            fragment.startActivityForResult(i, requestCode);
+        else {
+            ToastUtils.showToast(errorResId);
+        }
+    }
+
+    /**
+     * Adds a given picture to the device images gallery
+     *
+     * @param imageUri The {@link Uri} of the image
+     */
+    public static void addPictureToDeviceGallery(Uri imageUri) {
+        Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+        mediaScanIntent.setData(imageUri);
+        ContextUtils.getAppContext().sendBroadcast(mediaScanIntent);
+    }
+
+    /**
+     * Triggers an intent to go to the device's camera app, stores the image as 'filename'.'format',
+     * and returns its {@link Uri}
+     * <p>
+     * <p/>
+     * Override the onActivityResult method in your fragment and specify behaviour
+     * for the provided request code. This method returns a File object that
+     * contains the picture taken. You can get the returned image as an Uri using
+     * Uri.fromFile(getImageFromCamera(fragment));
+     *
+     * @param fragment    A fragment where the get image intent is going to be called
+     * @param requestCode A request code for the intent
+     * @param filename    Filename for the future stored image
+     * @param format      Format (extension) for the future image
+     * @param errorResId  Resource id of the error string
+     * @return {@link Uri} of the newly stored image
+     */
+    @Nullable
+    public static Uri getImageFromCamera(Fragment fragment, int requestCode, String filename,
+                                         @ImageFormat String format, @StringRes int errorResId) {
+
+        Intent i = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+
+        // Ensure that there's a camera app to handle the intent
+        if (i.resolveActivity(ContextUtils.getAppContext().getPackageManager()) != null) {
+            File photoFile = null;
+
+            try {
+                photoFile = FileUtils.createFile(filename, format);
+            } catch (IOException ex) {
+                ToastUtils.showToast(errorResId);
+            }
+
+            Uri photoFileUri = Uri.fromFile(photoFile);
+
+            if (photoFile != null) {
+                i.putExtra(MediaStore.EXTRA_OUTPUT, photoFileUri);
+                fragment.startActivityForResult(i, requestCode);
+            }
+
+            return photoFileUri;
+        } else {
+            ToastUtils.showToast(errorResId);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get PNG representation from a {@link Bitmap}.
+     *
+     * @param bitmap target Bitmap
+     *
+     * @return byte array with the PNG information of the Bitmap
+     */
+    public static byte[] generatePngByteArray(Bitmap bitmap) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.PNG, 80, bytes);
+
+        return bytes.toByteArray();
+    }
+
+    /**
+     * Get PNG from an image file, represented by its {@link Uri}
+     *
+     * @param imageFileUri target image file URI
+     *
+     * @return byte array with the PNG information of the image file.
+     */
+    public static byte[] generatePngByteArray(Uri imageFileUri) {
+        Bitmap imageBitmap = BitmapFactory.decodeFile(FileUtils.getRealPathFromUri(imageFileUri));
+
+        return generatePngByteArray(imageBitmap);
+    }
+
+}

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
@@ -117,44 +117,57 @@ public class ImageUtils {
     }
 
     /**
-     * Get PNG representation from a {@link Bitmap}.
+     * Get {@link byte[]} representation from a {@link Bitmap}, with boundaries.
      *
      * @param bitmap target Bitmap
      * @param format image compress format
      * @param quality compress quality, between 0 and 100
+     * @param maxHeight max height of the target image
+     * @param maxWidth max width of the target image
      *
-     * @return byte array with the formatted information of the Bitmap
+     * @return byte array with the formatted information of the Bitmap, if the image exceeded
+     *          boundaries, it's re scaled.
      */
     public static byte[] getImageAsByteArray(
             Bitmap bitmap,
             Bitmap.CompressFormat format,
-            @IntRange(from = 0, to = 100) int quality) {
+            @IntRange(from = 0, to = 100) int quality,
+            int maxWidth,
+            int maxHeight) {
 
+        Bitmap targetBitmap = resize(bitmap, maxWidth, maxHeight);
 
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        bitmap.compress(format, sanitizeQuality(quality), bytes);
+        targetBitmap.compress(format, sanitizeQuality(quality), bytes);
 
         return bytes.toByteArray();
     }
 
     /**
-     * Get PNG from an image file, represented by its {@link Uri}
+     * Get {@link byte[]} from an image file, represented by its {@link Uri}
      *
      * @param imageFileUri target image file URI
      * @param format image compress format
      * @param quality compress quality, between 0 and 100
+     * @param maxHeight max height of the target image
+     * @param maxWidth max width of the target image
      *
-     * @return byte array with the formatted information of the image file
+     * @return byte array with the formatted information of the image file, if the image exceeded
+     *          boundaries, it's re scaled.
      */
     public static byte[] getImageAsByteArray(
             Uri imageFileUri,
             Bitmap.CompressFormat format,
-            @IntRange(from = 0, to = 100) int quality) {
+            @IntRange(from = 0, to = 100) int quality,
+            int maxWidth,
+            int maxHeight) {
 
         return getImageAsByteArray(
                 BitmapFactory.decodeFile(FileUtils.getRealPathFromUri(imageFileUri)),
                 format,
-                quality);
+                quality,
+                maxWidth,
+                maxHeight);
     }
 
     /**
@@ -168,6 +181,40 @@ public class ImageUtils {
         if (quality < 0) return 0;
         else if (quality > 100) return 100;
         return quality;
+    }
+
+    /**
+     *
+     * @param image
+     * @param maxWidth
+     * @param maxHeight
+     *
+     * @return
+     */
+    public static Bitmap resize(Bitmap image, int maxWidth, int maxHeight) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        if (maxWidth > 0 && maxHeight > 0 && (width > maxWidth || height > maxHeight)) {
+
+            float ratioImage = (float) width / (float) height;
+
+            int finalWidth = maxWidth;
+            int finalHeight = maxHeight;
+            if (ratioImage > 1) {
+                finalHeight = (int) ((float)finalWidth / ratioImage);
+            } else {
+                finalWidth = (int) ((float)finalHeight * ratioImage);
+            }
+
+            Bitmap resizedImage = Bitmap.createScaledBitmap(image, finalWidth, finalHeight, true);
+
+            if (image != resizedImage) image.recycle();
+
+            return resizedImage;
+        } else {
+            return image;
+        }
     }
 
 }

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.provider.MediaStore;
+import android.support.annotation.IntRange;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 import android.support.annotation.StringRes;
@@ -45,9 +46,7 @@ public class ImageUtils {
      * @author juanignaciomolina
      */
     public static void getImageFromGallery(Fragment fragment, int requestCode, @StringRes int errorResId) {
-        Intent i = new Intent(
-                Intent.ACTION_PICK,
-                MediaStore.Images.Media.INTERNAL_CONTENT_URI);
+        Intent i = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI);
         i.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
 
         // Ensure that there's a gallery app to handle the intent
@@ -121,12 +120,19 @@ public class ImageUtils {
      * Get PNG representation from a {@link Bitmap}.
      *
      * @param bitmap target Bitmap
+     * @param format image compress format
+     * @param quality compress quality, between 0 and 100
      *
-     * @return byte array with the PNG information of the Bitmap
+     * @return byte array with the formatted information of the Bitmap
      */
-    public static byte[] generatePngByteArray(Bitmap bitmap) {
+    public static byte[] getImageAsByteArray(
+            Bitmap bitmap,
+            Bitmap.CompressFormat format,
+            @IntRange(from = 0, to = 100) int quality) {
+
+
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        bitmap.compress(Bitmap.CompressFormat.PNG, 80, bytes);
+        bitmap.compress(format, sanitizeQuality(quality), bytes);
 
         return bytes.toByteArray();
     }
@@ -135,13 +141,33 @@ public class ImageUtils {
      * Get PNG from an image file, represented by its {@link Uri}
      *
      * @param imageFileUri target image file URI
+     * @param format image compress format
+     * @param quality compress quality, between 0 and 100
      *
-     * @return byte array with the PNG information of the image file.
+     * @return byte array with the formatted information of the image file
      */
-    public static byte[] generatePngByteArray(Uri imageFileUri) {
-        Bitmap imageBitmap = BitmapFactory.decodeFile(FileUtils.getRealPathFromUri(imageFileUri));
+    public static byte[] getImageAsByteArray(
+            Uri imageFileUri,
+            Bitmap.CompressFormat format,
+            @IntRange(from = 0, to = 100) int quality) {
 
-        return generatePngByteArray(imageBitmap);
+        return getImageAsByteArray(
+                BitmapFactory.decodeFile(FileUtils.getRealPathFromUri(imageFileUri)),
+                format,
+                quality);
+    }
+
+    /**
+     * Prevents quality from being outside 0...100 range
+     *
+     * @param quality target quality
+     *
+     * @return if below 0, returns 0, if above 100, return 100, else returns {@code quality} param
+     */
+    private static int sanitizeQuality(int quality) {
+        if (quality < 0) return 0;
+        else if (quality > 100) return 100;
+        return quality;
     }
 
 }


### PR DESCRIPTION
### Summary

This code provides image retrieving utilities through ```GetImageFragment``` implementation which has shortcuts for starting the gallery/camera and retrieving exposing a ```Uri``` of the corresponding image.

In the case of the gallery, it just obtains its ```Uri```, and in the camera case it stores a new file, with name ```GetImageFragment#pictureTakenFilename``` name and then expose its ```Uri```. 

Also, ```FileUtils``` and ```ImageUtils``` were added along by requirement ```GetImageFragment``` usage.