### PR TITLE
Back press handling

### DIFF
--- a/core/src/main/java/ar/com/wolox/wolmo/core/activity/WoloxActivity.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/activity/WoloxActivity.java
@@ -7,6 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import ar.com.wolox.wolmo.core.R;
+import ar.com.wolox.wolmo.core.fragment.IWoloxFragment;
 import ar.com.wolox.wolmo.core.permission.PermissionManager;
 import ar.com.wolox.wolmo.core.util.ToastUtils;
 
@@ -98,5 +99,24 @@ public abstract class WoloxActivity extends AppCompatActivity {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         PermissionManager.getInstance()
                 .onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    /**
+     * Custom behaviour that calls, for every child fragment that is an instance of
+     * {@link IWoloxFragment} and {@link Fragment#isVisible()}, its
+     * {@link IWoloxFragment#onBackPressed()}.
+     *
+     * If any of those returns 'true', the method returns. Else, it calls
+     * {@link AppCompatActivity#onBackPressed()}.
+     */
+    @Override
+    public void onBackPressed() {
+        for (Fragment childFragment : getSupportFragmentManager().getFragments()) {
+            if (childFragment instanceof IWoloxFragment && childFragment.isVisible()) {
+                if (((IWoloxFragment) childFragment).onBackPressed()) return;
+            }
+        }
+
+        super.onBackPressed();
     }
 }

--- a/core/src/main/java/ar/com/wolox/wolmo/core/activity/WoloxActivity.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/activity/WoloxActivity.java
@@ -6,6 +6,8 @@ import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
+import java.util.List;
+
 import ar.com.wolox.wolmo.core.R;
 import ar.com.wolox.wolmo.core.fragment.IWoloxFragment;
 import ar.com.wolox.wolmo.core.permission.PermissionManager;
@@ -109,11 +111,17 @@ public abstract class WoloxActivity extends AppCompatActivity {
      * If any of those returns 'true', the method returns. Else, it calls
      * {@link AppCompatActivity#onBackPressed()}.
      */
+    @SuppressWarnings("RestrictedApi")
     @Override
     public void onBackPressed() {
-        for (Fragment childFragment : getSupportFragmentManager().getFragments()) {
-            if (childFragment instanceof IWoloxFragment && childFragment.isVisible()) {
-                if (((IWoloxFragment) childFragment).onBackPressed()) return;
+        List<Fragment> fragments = getSupportFragmentManager().getFragments();
+
+        // If activity has no child fragments, the list is null
+        if (fragments != null) {
+            for (Fragment childFragment : fragments) {
+                if (childFragment instanceof IWoloxFragment && childFragment.isVisible()) {
+                    if (((IWoloxFragment) childFragment).onBackPressed()) return;
+                }
             }
         }
 

--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/GetImageFragment.java
@@ -145,8 +145,7 @@ public abstract class GetImageFragment<T extends BasePresenter> extends WoloxFra
      *
      * @param onImageReturnCallback callback for request result
      */
-    protected void takePicture(
-            @NonNull final OnImageReturnCallback onImageReturnCallback) {
+    protected void takePicture(@NonNull final OnImageReturnCallback onImageReturnCallback) {
         PermissionManager.getInstance().requirePermission(
                 this,
                 new PermissionListener() {

--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/IWoloxFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/IWoloxFragment.java
@@ -45,12 +45,19 @@ public interface IWoloxFragment<T extends BasePresenter> {
     public void setListeners();
 
     /**
-     * Override this method is you want to do anything when the fragmnent becomes visible
+     * Override this method is you want to do anything when the fragment becomes visible
      */
     void onVisible();
 
     /**
-     * Override this method is you want to do anything when the fragmnent hides
+     * Override this method is you want to do anything when the fragment hides
      */
     void onHide();
+
+    /**
+     * Custom back press handling method.
+     *
+     * @return 'true' if the back was handled and shouldn't propagate, 'false' otherwise
+     */
+    boolean onBackPressed();
 }

--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/WoloxDialogFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/WoloxDialogFragment.java
@@ -1,5 +1,6 @@
 package ar.com.wolox.wolmo.core.fragment;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.graphics.Color;
@@ -43,6 +44,25 @@ public abstract class WoloxDialogFragment<T extends BasePresenter> extends Dialo
             getDialog().getWindow().setBackgroundDrawable(backgroundDrawable);
             setOnBackPressedListener();
         }
+    }
+
+    /**
+     * Sets a custom {@link android.content.DialogInterface.OnKeyListener} for the
+     * {@link Dialog} returned by {@link #getDialog()} that calls {@link #onBackPressed()}
+     * if the key is the back key.
+     *
+     * Beware that, when clicking a key, the {@link android.content.DialogInterface.OnKeyListener}
+     * is called before delegating the event to other structures. For example, the back is handled
+     * here before sending it to an {@link Activity}.
+     */
+    private void setOnBackPressedListener() {
+        if (getDialog() == null) return;
+        getDialog().setOnKeyListener(new Dialog.OnKeyListener() {
+            @Override
+            public boolean onKey(DialogInterface arg0, int keyCode, KeyEvent event) {
+                return keyCode == KeyEvent.KEYCODE_BACK && onBackPressed();
+            }
+        });
     }
 
     @Override
@@ -113,25 +133,14 @@ public abstract class WoloxDialogFragment<T extends BasePresenter> extends Dialo
     }
 
     /**
-     * Override this method as a callback when navigation back button is pressed. Returning false
-     * will execute the default behavior and close the dialog.
+     * @see IWoloxFragment#onBackPressed()
+     *
+     * Beware, when overriding, that returning 'true' will prevent default navigation behaviour such
+     * as {@link Dialog#dismiss()}.
      */
+    @Override
     public boolean onBackPressed() {
         return false;
-    }
-
-    private void setOnBackPressedListener() {
-        if (getDialog() == null) return;
-        getDialog().setOnKeyListener(new Dialog.OnKeyListener() {
-            @Override
-            public boolean onKey(DialogInterface arg0, int keyCode,
-                                 KeyEvent event) {
-                if (keyCode == KeyEvent.KEYCODE_BACK) {
-                    return onBackPressed();
-                }
-                return false;
-            }
-        });
     }
 
     @Override

--- a/core/src/main/java/ar/com/wolox/wolmo/core/fragment/WoloxFragment.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/fragment/WoloxFragment.java
@@ -1,8 +1,10 @@
 package ar.com.wolox.wolmo.core.fragment;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -76,5 +78,17 @@ public abstract class WoloxFragment<T extends BasePresenter> extends Fragment
 
     @Override
     public void onHide() {
+    }
+
+    /**
+     * @see IWoloxFragment#onBackPressed()
+     *
+     * Beware, when overriding, that returning 'true' will prevent default navigation behaviour such
+     * as {@link FragmentManager#popBackStackImmediate()} or {@link Activity#finish()}, but not
+     * dismissing the keyboard, for example.
+     */
+    @Override
+    public boolean onBackPressed() {
+        return false;
     }
 }

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/FileUtils.java
@@ -28,14 +28,14 @@ public class FileUtils {
      *
      * @return {@link File} result of the creation
      *
-     * @throws IOException if a file could not be created
+     * @throws IOException If a file could not be created
      */
     public static File createFile(
             @NonNull String filename, @NonNull String extension) throws IOException {
         File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
 
         //The suffix will be appended as it is, we need to add the dot manually
-        if (!extension.startsWith("."))
+        if (!extension.startsWith(".")) {
             extension = "." + extension;
         }
 


### PR DESCRIPTION
### Summary

Now providing back press handling methods through `IWoloxFragment#onBackPressed` method. The way the delegation is done to those methods is the following:

* For `WoloxFragment`, the `WoloxActivity` overrides its `onBackPressed` method and calls the `IWoloxFragment#onBackPressed` for every child fragment that implements that interface and is visible.

* For `WoloxDialogFragment`, this is done differently since we want the dialogs' back behaviour to mask any underlying back handling logic. An `Dialog.OnKeyListener` is attached to its inner `Dialog` which listens to back press events and calls `IWoloxFragment#onBackPressed` when it occurs.

### Notes for the Reviewer

Review/merge after (https://github.com/Wolox/wolmo-core-android/pull/11) is merged.