### PR TITLE
Camera fix

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -7,6 +7,16 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
@@ -95,7 +95,7 @@ public class ImageUtils {
      * @return {@link Uri} of the newly stored image
      */
     @Nullable
-    public static Uri getImageFromCamera(
+    public static File getImageFromCamera(
             @NonNull Fragment fragment, int requestCode, @NonNull String filename,
             @ImageFormat String format, @StringRes int errorResId) {
 
@@ -121,7 +121,7 @@ public class ImageUtils {
         i.putExtra(MediaStore.EXTRA_OUTPUT, photoFileUri);
         fragment.startActivityForResult(i, requestCode);
 
-        return photoFileUri;
+        return photoFile;
     }
 
     /**
@@ -172,6 +172,33 @@ public class ImageUtils {
 
         return getImageAsByteArray(
                 BitmapFactory.decodeFile(FileUtils.getRealPathFromUri(imageFileUri)),
+                format,
+                quality,
+                maxWidth,
+                maxHeight);
+    }
+
+    /**
+     * Get {@link byte[]} from an image {@link File}
+     *
+     * @param file         target image file
+     * @param format       image compress format
+     * @param quality      compress quality, between 0 and 100
+     * @param maxWidth     max width of the target image
+     * @param maxHeight    max height of the target image
+     *
+     * @return byte array with the formatted information of the image file, if the image exceeded
+     *          boundaries, it's re scaled.
+     */
+    public static byte[] getImageAsByteArray(
+            @NonNull File file,
+            @NonNull Bitmap.CompressFormat format,
+            @IntRange(from = 0, to = 100) int quality,
+            int maxWidth,
+            int maxHeight) {
+
+        return getImageAsByteArray(
+                BitmapFactory.decodeFile(file.getPath()),
                 format,
                 quality,
                 maxWidth,

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
@@ -109,19 +109,17 @@ public class ImageUtils {
         }
 
         File photoFile;
-
         try {
             photoFile = FileUtils.createFile(filename, format);
         } catch (IOException ex) {
             ToastUtils.showToast(errorResId);
-
             return null;
         }
 
-//        Uri photoFileUri = Uri.fromFile(photoFile);
-
+        // Change in API 24 to get the file
         Uri photoFileUri = FileProvider.getUriForFile(fragment.getContext(),
-                fragment.getContext().getPackageName() + ".provider", photoFile);
+            fragment.getContext().getPackageName() + ".provider", photoFile);
+
         i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         i.putExtra(MediaStore.EXTRA_OUTPUT, photoFileUri);
         fragment.startActivityForResult(i, requestCode);

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/ImageUtils.java
@@ -11,6 +11,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringDef;
 import android.support.annotation.StringRes;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.FileProvider;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -117,7 +118,11 @@ public class ImageUtils {
             return null;
         }
 
-        Uri photoFileUri = Uri.fromFile(photoFile);
+//        Uri photoFileUri = Uri.fromFile(photoFile);
+
+        Uri photoFileUri = FileProvider.getUriForFile(fragment.getContext(),
+                fragment.getContext().getPackageName() + ".provider", photoFile);
+        i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         i.putExtra(MediaStore.EXTRA_OUTPUT, photoFileUri);
         fragment.startActivityForResult(i, requestCode);
 

--- a/core/src/main/res/xml/provider_paths.xml
+++ b/core/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
### Summary
Now returning the file instead of the Uri, because the Uri was causing a crash. In previous projects we also handled the file directly. We can still get the Uri from the fragment using Uri.fromFile(), and the getImageAsByte Array() method is very similar.