### PR TITLE
Manifest: icon removed

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <application android:allowBackup="true"
         android:label="@string/app_name"
-        android:icon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 


### PR DESCRIPTION
### Summary

The icon has been removed from the manifest file, since every app will use its own. This avoids the use of the attribute tools:replace="android:icon".

### Screenshots

N/A

### Trello card

N/A