### PR TITLE
Bump Android versions to API 26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url "https://maven.google.com" }
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,18 +2,18 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jakewharton.butterknife'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         consumerProguardFiles 'proguard-joda-time.pro', 'proguard-butterknife.pro'
     }
 }
 
 buildscript {
-    ext.support_library_version = '25.3.1'
+    ext.support_library_version = '26.1.0'
     ext.butterknife_version = '8.6.0'
     ext.joda_time_version = '2.9.9'
 }


### PR DESCRIPTION
## Summary

Update `build.gradle` dependencies to match API 26, along with updates to other dependencies.