### PR TITLE
Update build.gradle to generate sources and javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
-        classpath 'com.jakewharton:butterknife-gradle-plugin:8.5.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.jakewharton.butterknife'
 apply plugin: 'jacoco-android'
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = 'com.github.Wolox'
 
 android {
     compileSdkVersion 27
@@ -36,7 +38,7 @@ coveralls {
 }
 
 buildscript {
-    ext.support_library_version = '27.1.0'
+    ext.support_library_version = '27.1.1'
     ext.butterknife_version = '9.0.0-SNAPSHOT'
     ext.dagger_version = '2.13'
     ext.powermock_version = '1.7.0'
@@ -65,4 +67,26 @@ dependencies {
     testImplementation "org.assertj:assertj-core:3.9.0"
     testAnnotationProcessor "com.google.dagger:dagger-compiler:$dagger_version"
     testAnnotationProcessor "com.google.dagger:dagger-android-processor:$dagger_version"
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    failOnError  false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
 }


### PR DESCRIPTION
# Summary
* Update build.gradle to generate sources and javadocs
* Remove butterknife plugin
* Bump suppor library

# Description
This pull request adds `javadocs` and `sources` tasks so it can be seen inside the Android Studio (or in the jitpack website).
The butterknife plugin was removed because it has no use in a [library](https://github.com/JakeWharton/butterknife/issues/100). The dependency remains so we don't need to add it in the projects, but the gradle plugin only runs in apps.