### PR TITLE
Downgrade butterknife version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -49,7 +49,8 @@ dependencies {
     api "com.android.support:appcompat-v7:$support_library_version"
 
     // ButterKnife
-    api "com.jakewharton:butterknife:$butterknife_version"
+    implementation "com.jakewharton:butterknife:$butterknife_version"
+    annotationProcessor "com.jakewharton:butterknife-compiler:$butterknife_version"
 
     // Dagger
     api "com.google.dagger:dagger:$dagger_version"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,8 +36,8 @@ coveralls {
 }
 
 buildscript {
-    ext.support_library_version = '27.1.0'
-    ext.butterknife_version = '9.0.0-SNAPSHOT'
+    ext.support_library_version = '27.1.1'
+    ext.butterknife_version = '8.8.1'
     ext.dagger_version = '2.13'
     ext.powermock_version = '1.7.0'
 }


### PR DESCRIPTION
## Summary

Downgrade `Butterknife` version and set it to `implementation` to fix CI.

Version `9.0.0-SNAPSHOT` was taken down. In the near future, https://github.com/Wolox/WoloxAndroidBootstrap will remove the `Butterknife` dependency so this is not a breaking change.