### PR TITLE
BindingViewHolder

### DIFF
--- a/core/src/main/java/ar/com/wolox/wolmo/core/adapter/BindingViewHolder.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/adapter/BindingViewHolder.kt
@@ -1,0 +1,10 @@
+package ar.com.wolox.wolmo.core.adapter
+
+import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class BindingViewHolder<T, out V : ViewDataBinding>(val binding: V) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    abstract fun bind(item: T)
+}


### PR DESCRIPTION
### Summary

- Added a BindingViewHolder that allows the usage of View Binding inside ViewHolders. We used it in several projects and it was never added to Wolmo.