### PR TITLE
New logger

### DIFF
--- a/core/src/main/java/ar/com/wolox/wolmo/core/extensions/AnyExtensions.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/extensions/AnyExtensions.kt
@@ -1,0 +1,14 @@
+package ar.com.wolox.wolmo.core.extensions
+
+import java.lang.Exception
+
+private const val EMPTY_INVOKE_STRING = "kotlin.Unit"
+private const val NULL_STRING = "null"
+
+fun (() -> Any?).toStringSafely(): String? = try {
+    with(this.invoke().toString()) {
+        return if (this == EMPTY_INVOKE_STRING) String() else this
+    }
+} catch (e: Exception) {
+   NULL_STRING
+}

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/Logger.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/Logger.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
  * to simplify unit tests.
  * @deprecated use [WolmoLogger] instead.
  */
-@Deprecated("User WolmoLogger Instead")
+@Deprecated("Use WolmoLogger instead.")
 class Logger @Inject constructor() {
 
     /** [tag] used to identify the source of a log message. */

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/Logger.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/Logger.kt
@@ -7,7 +7,9 @@ import javax.inject.Inject
 /**
  * Wrapper of [Log] to simplify logs in the same class by reusing the tag and
  * to simplify unit tests.
+ * @deprecated use [WolmoLogger] instead.
  */
+@Deprecated("User WolmoLogger Instead")
 class Logger @Inject constructor() {
 
     /** [tag] used to identify the source of a log message. */
@@ -15,7 +17,8 @@ class Logger @Inject constructor() {
 
     /** Send a [Log.VERBOSE] log a [message] and an [exception] with a [tag] to identify the source of it. */
     @JvmOverloads
-    fun v(tag: String?, message: String, exception: Throwable? = null) = Log.v(tag, message, exception)
+    fun v(tag: String?, message: String, exception: Throwable? = null) =
+        Log.v(tag, message, exception)
 
     /** Send a [Log.VERBOSE] log a [message] and an [exception] using the predefined [tag]. */
     @JvmOverloads
@@ -23,7 +26,8 @@ class Logger @Inject constructor() {
 
     /** Send a [Log.DEBUG] log a [message] and an [exception] with a [tag] to identify the source of it. */
     @JvmOverloads
-    fun d(tag: String?, message: String, exception: Throwable? = null) = Log.d(tag, message, exception)
+    fun d(tag: String?, message: String, exception: Throwable? = null) =
+        Log.d(tag, message, exception)
 
     /** Send a [Log.DEBUG] log a [message] and an [exception] using the predefined [tag]. */
     @JvmOverloads
@@ -31,7 +35,8 @@ class Logger @Inject constructor() {
 
     /** Send a [Log.INFO] log a [message] and an [exception] with a [tag] to identify the source of it. */
     @JvmOverloads
-    fun i(tag: String?, message: String, exception: Throwable? = null) = Log.i(tag, message, exception)
+    fun i(tag: String?, message: String, exception: Throwable? = null) =
+        Log.i(tag, message, exception)
 
     /** Send a [Log.INFO] log a [message] and an [exception] using the predefined [tag]. */
     @JvmOverloads
@@ -39,7 +44,8 @@ class Logger @Inject constructor() {
 
     /** Send a [Log.WARN] log a [message] and an [exception] with a [tag] to identify the source of it. */
     @JvmOverloads
-    fun w(tag: String?, message: String, exception: Throwable? = null) = Log.w(tag, message, exception)
+    fun w(tag: String?, message: String, exception: Throwable? = null) =
+        Log.w(tag, message, exception)
 
     /** Send a [Log.WARN] log a [message] and an [exception] using the predefined [tag]. */
     @JvmOverloads
@@ -47,7 +53,8 @@ class Logger @Inject constructor() {
 
     /** Send a [Log.ERROR] log a [message] and an [exception] with a [tag] to identify the source of it. */
     @JvmOverloads
-    fun e(tag: String?, message: String, exception: Throwable? = null) = Log.e(tag, message, exception)
+    fun e(tag: String?, message: String, exception: Throwable? = null) =
+        Log.e(tag, message, exception)
 
     /** Send a [Log.ERROR] log a [message] and an [exception] using the predefined [tag]. */
     @JvmOverloads

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/WolmoLogger.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/WolmoLogger.kt
@@ -1,0 +1,35 @@
+package ar.com.wolox.wolmo.core.util
+
+import android.util.Log
+import ar.com.wolox.wolmo.core.extensions.orElse
+import ar.com.wolox.wolmo.core.extensions.toStringSafely
+
+object WolmoLogger {
+
+    private const val WOLMO_NAME = "WolmoCoreAndroid"
+    var tag: String? = null
+
+    fun log(exception: Throwable? = null, message : () -> Any?) {
+        Log.d(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
+    }
+
+    fun warn(exception: Throwable? = null, message : () -> Any?) {
+        Log.w(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
+    }
+
+    fun info(exception: Throwable? = null, message : () -> Any?) {
+        Log.i(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
+    }
+
+    fun verbose(exception: Throwable? = null, message : () -> Any?) {
+        Log.v(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
+    }
+
+    fun error(exception: Throwable? = null, message : () -> Any?) {
+        Log.e(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
+    }
+
+    fun terribleFailure(exception: Throwable? = null, message : () -> Any?) {
+        Log.wtf(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
+    }
+}

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/WolmoLogger.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/WolmoLogger.kt
@@ -9,6 +9,10 @@ object WolmoLogger {
     private const val WOLMO_NAME = "WolmoCoreAndroid"
     var tag: String? = null
 
+    fun resetTag() {
+        this.tag = null
+    }
+
     fun log(exception: Throwable? = null, message : () -> Any?) {
         Log.d(tag.orElse(WOLMO_NAME), message.toStringSafely(), exception)
     }

--- a/core/src/test/java/ar/com/wolox/wolmo/core/util/WolmoLoggerTest.kt
+++ b/core/src/test/java/ar/com/wolox/wolmo/core/util/WolmoLoggerTest.kt
@@ -1,0 +1,105 @@
+package ar.com.wolox.wolmo.core.util
+
+import android.os.Build
+import ar.com.wolox.wolmo.core.util.WolmoLogger.error
+import ar.com.wolox.wolmo.core.util.WolmoLogger.info
+import ar.com.wolox.wolmo.core.util.WolmoLogger.log
+import ar.com.wolox.wolmo.core.util.WolmoLogger.terribleFailure
+import ar.com.wolox.wolmo.core.util.WolmoLogger.verbose
+import ar.com.wolox.wolmo.core.util.WolmoLogger.warn
+import java.io.PrintStream
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.O_MR1])
+class WolmoLoggerTest {
+
+    private lateinit var printStreamMock: PrintStream
+    private lateinit var exceptionMock: Exception
+
+    @Before
+    fun setUp() {
+        WolmoLogger.resetTag()
+        printStreamMock = Mockito.mock(PrintStream::class.java)
+        ShadowLog.stream = printStreamMock
+        exceptionMock = Mockito.mock(Exception::class.java)
+        Mockito.doAnswer { invocation: InvocationOnMock ->
+            val stream = invocation.getArgument<PrintStream>(0)
+            stream.println("Stacktrace")
+            return@doAnswer false
+        }.`when`(exceptionMock).printStackTrace(
+            ArgumentMatchers.any(
+                PrintStream::class.java
+            )
+        )
+    }
+
+    @Test
+    fun logInDebugLevelShouldCallAndroidLog() {
+        log { "First string" }
+        WolmoLogger.tag = "TestTag"
+        log { "Second string" }
+        val inOrder = Mockito.inOrder(printStreamMock)
+        inOrder.verify(printStreamMock).println(eq("D/WolmoCoreAndroid: First string"))
+        inOrder.verify(printStreamMock).println(eq("D/TestTag: Second string"))
+    }
+
+    @Test
+    fun logInInfoLevelShouldCallAndroidLog() {
+        info { "First string" }
+        WolmoLogger.tag = "TestTag"
+        info { "Second string" }
+        val inOrder = Mockito.inOrder(printStreamMock)
+        inOrder.verify(printStreamMock).println(eq("I/WolmoCoreAndroid: First string"))
+        inOrder.verify(printStreamMock).println(eq("I/TestTag: Second string"))
+    }
+
+    @Test
+    fun logInWarningLevelShouldCallAndroidLog() {
+        warn { "First string" }
+        WolmoLogger.tag = "TestTag"
+        warn { "Second string" }
+        val inOrder = Mockito.inOrder(printStreamMock)
+        inOrder.verify(printStreamMock).println(eq("W/WolmoCoreAndroid: First string"))
+        inOrder.verify(printStreamMock).println(eq("W/TestTag: Second string"))
+    }
+
+    @Test
+    fun logInErrorLevelShouldCallAndroidLog() {
+        error { "First string" }
+        WolmoLogger.tag = "TestTag"
+        error { "Second string" }
+        val inOrder = Mockito.inOrder(printStreamMock)
+        inOrder.verify(printStreamMock).println(eq("E/WolmoCoreAndroid: First string"))
+        inOrder.verify(printStreamMock).println(eq("E/TestTag: Second string"))
+    }
+
+    @Test
+    fun logInVerboseLevelShouldCallAndroidLog() {
+        verbose { "First string" }
+        WolmoLogger.tag = "TestTag"
+        verbose { "Second string" }
+        val inOrder = Mockito.inOrder(printStreamMock)
+        inOrder.verify(printStreamMock).println(eq("V/WolmoCoreAndroid: First string"))
+        inOrder.verify(printStreamMock).println(eq("V/TestTag: Second string"))
+    }
+
+    @Test
+    fun logInTerribleFailureLevelShouldCallAndroidLog() {
+        terribleFailure { "First string" }
+        WolmoLogger.tag = "TestTag"
+        terribleFailure { "Second string" }
+        val inOrder = Mockito.inOrder(printStreamMock)
+        inOrder.verify(printStreamMock).println(eq("A/WolmoCoreAndroid: First string"))
+        inOrder.verify(printStreamMock).println(eq("A/TestTag: Second string"))
+    }
+}


### PR DESCRIPTION
### Summary

- Deprecated the old `Logger`.
- Added a new logger called `WolmoLogger` with some extra features like class logging. 

### Usage

WolmoLogger supports every logging level:
- Debug level (Log.d): `log { "Hi" }`,` og { user } `
- Verbose level (Log.v): `verbose { "Hi" }`, `verbose { user }` 
- Info level (Log.i): `info { "Hi" }`, `info { user }` 
- Warning level (Log.w): `warn { "Hi" }`, `warn { user } `
- Error level (Log.e): `warn { "Hi" }`, `warn { user } `
- Terrible failure level (Log.wtf): `terribleFailure { "Hi" }`, `terribleFailure { user } `

If you need to change the tag, you can just update it like:
`WolmoLogger.tag = "MyTag"`