### PR TITLE
Single click listener

### DIFF
--- a/core/src/main/java/ar/com/wolox/wolmo/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/extensions/ViewExtensions.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
+import ar.com.wolox.wolmo.core.util.SingleClickListener
 
 /** Inflate a [layoutRes] inside a [ViewGroup]. */
 fun ViewGroup.inflate(@LayoutRes layoutRes: Int, attachToRoot: Boolean = false): View {
@@ -20,3 +21,6 @@ fun TextView.setTextOrGone(newText: String?) {
     isVisible = !newText.isNullOrEmpty()
     text = newText
 }
+
+fun View.setOnSingleClickListener(click: (View) -> Unit) =
+    setOnClickListener(SingleClickListener(click))

--- a/core/src/main/java/ar/com/wolox/wolmo/core/util/SingleClickListener.kt
+++ b/core/src/main/java/ar/com/wolox/wolmo/core/util/SingleClickListener.kt
@@ -1,0 +1,24 @@
+package ar.com.wolox.wolmo.core.util
+
+import android.view.View
+
+class SingleClickListener(
+    private val click: ((View) -> Unit)
+) : View.OnClickListener {
+
+    override fun onClick(view: View) {
+        if (enabled) {
+            enabled = false
+            view.postDelayed(ENABLE_AGAIN, INTERVAL_MILLIS)
+            click(view)
+        }
+    }
+
+    companion object {
+        private const val INTERVAL_MILLIS = 1000L
+        @JvmStatic
+        var enabled = true
+        private val ENABLE_AGAIN =
+            Runnable { enabled = true }
+    }
+}


### PR DESCRIPTION
### Summary

Added a SingleClickListener. This simple listener avoids opening multiple button clicks in slower devices (for instance, when we click a button twice and two activities are instantiated).